### PR TITLE
Fix parsing filters value

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -81,7 +81,7 @@ class Filter
             // is string present?
             if (strpos($query, $oper)) {
                 // Split string into array
-                $parts = explode($oper, $query);
+                $parts = explode($oper, $query, 2);
 
                 return [
                     'field' => $parts[0],

--- a/tests/EADS/Filters/FilterTest.php
+++ b/tests/EADS/Filters/FilterTest.php
@@ -54,6 +54,11 @@ class FilterTest extends \TestCase
             'field' => 'id',
             'oper' => '<',
             'value' => ['1234']
+        ],
+        "id==1234==567" => [
+            'field' => 'id',
+            'oper' => '==',
+            'value' => ['1234==567']
         ]
     ];
 


### PR DESCRIPTION
When the filter value contains `==` parser trims its value